### PR TITLE
show help when command is missing

### DIFF
--- a/bin/dpm
+++ b/bin/dpm
@@ -91,6 +91,9 @@ if (argv._[0] === 'init') {
   } else {
     console.log(optimist.help());
   }
+} else if (!argv._[0]){
+  console.log(optimist.help());
+  _fail(new Error('missing command'));  
 } else {
   _fail(new Error('invalid command'));
 };


### PR DESCRIPTION
addresses #39
shows an error message `dpm ERR! missing command` for sake of clarity, not sure if this is necessary