### PR TITLE
Move Inline Data Example Into Repository

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -51,8 +51,8 @@ describe('get', function() {
 
   it('should ignore data resource', function(done) {
     var ours = new dpm({}, root);
-    var url = 'https://github.com/waylonflinn/datapackage-example-inline';
-    var dpjson = path.join(root, 'datapackages', 'datapackage-example-inline', 'datapackage.json')
+    var url = 'https://github.com/okfn/dpm/tree/master/test/fixtures/datapackage-example-inline';
+    var dpjson = path.join(root, 'datapackages', 'datapackage-example-inline', 'datapackage.json');
 
     ours.get(url, function(err) {
       if (err) return done(err);

--- a/test/fixtures/datapackage-example-inline/README.md
+++ b/test/fixtures/datapackage-example-inline/README.md
@@ -1,0 +1,1 @@
+This is a basic example of using an inline data element in a datapackage. Adapted from the documentation.

--- a/test/fixtures/datapackage-example-inline/datapackage.json
+++ b/test/fixtures/datapackage-example-inline/datapackage.json
@@ -1,0 +1,10 @@
+{
+  "name" : "datapackage-example-inline",
+  "license" : "CC0",
+  "resources": [
+     {
+        "format": "csv",
+        "data": "A,B,C\n1,2,3\n4,5,6"
+     }
+   ]
+}


### PR DESCRIPTION
This adds the recently added test data for inline data elements to the `test/fixtures` directory.

There's a hidden catch-22 here. The tests won't pass for this PR, until after it's merged. I've done what I can to ensure that they'll work after the merge, but we should stay vigilant shortly after merging to ensure it works.