### PR TITLE
fix test url for inline data

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -51,7 +51,7 @@ describe('get', function() {
 
   it('should ignore data resource', function(done) {
     var ours = new dpm({}, root);
-    var url = 'https://github.com/okfn/dpm/tree/master/test/fixtures/datapackage-example-inline';
+    var url = 'https://raw.githubusercontent.com/okfn/dpm/master/test/fixtures/datapackage-example-inline';
     var dpjson = path.join(root, 'datapackages', 'datapackage-example-inline', 'datapackage.json');
 
     ours.get(url, function(err) {


### PR DESCRIPTION
This should make the tests pass again.

In the process of fixing this I believe I found a bug in the `datapackage-identifier` module related to github urls. If I can reproduce it, I'll open an issue on that repository.

This fix bypasses the github url translation from that module.